### PR TITLE
Restrict GitHub Actions permissions to least privilege

### DIFF
--- a/.github/workflows/ci-actionlint.yml
+++ b/.github/workflows/ci-actionlint.yml
@@ -10,9 +10,7 @@ on:
     paths:
       - '.github/workflows/*.yml'
 
-permissions:
-  contents: read
-  pull-requests: write
+permissions: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -22,6 +20,9 @@ jobs:
   actionlint:
     runs-on: ubuntu-latest
     timeout-minutes: 3
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@v6
       - name: Check workflow files

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,7 @@ on:
     branches:
       - master
 
-permissions:
-  contents: read
+permissions: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -21,6 +20,8 @@ jobs:
   swiftformat:
     runs-on: ubuntu-latest
     timeout-minutes: 2
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@v6
@@ -35,6 +36,8 @@ jobs:
   swiftlint:
     runs-on: ubuntu-latest
     timeout-minutes: 2
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@v6
@@ -49,6 +52,8 @@ jobs:
     if: github.event.pull_request.draft == false
     runs-on: macos-26
     timeout-minutes: 20
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
 
@@ -92,6 +97,8 @@ jobs:
     if: github.event.pull_request.draft == false
     runs-on: macos-26
     timeout-minutes: 30
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,8 +3,7 @@ name: Deploy
 on:
   workflow_dispatch:
 
-permissions:
-  contents: read
+permissions: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -14,6 +13,8 @@ jobs:
   build:
     runs-on: macos-26
     timeout-minutes: 20
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
Set top-level `permissions: {}` to deny all by default and grant minimum required permissions to each job individually.