### PR TITLE
Fix Swift Concurrency warnings

### DIFF
--- a/FirstTask/Model/Task.swift
+++ b/FirstTask/Model/Task.swift
@@ -170,19 +170,20 @@ extension Task {
         }
     }
 
-    static func countTodayTasks(done: @escaping (Int) -> Void) {
+    static func countTodayTasks(done: @escaping @Sendable (Int) -> Void) {
         let user = User(id: Auth.auth().currentUser?.uid ?? "NotFound")
+        let tagsCollection = user.collection(path: .tags)
+        let tasksCollection = user.collection(path: .tasks)
 
-        user
-            .collection(path: .tags)
+        tagsCollection
             .whereField("kind", isEqualTo: "today")
             .getDocuments(completion: { snapshot, err in
                 guard err == nil else { return }
 
                 let todayTag = try? Tag(snapshot: snapshot!.documents[0])
                 if let todayTag = todayTag {
-                    user
-                        .collection(path: .tasks)
+                    let todayTagId = todayTag.id
+                    tasksCollection
                         .getDocuments(completion: { snapshot, err in
                             guard err == nil else { return }
 
@@ -191,7 +192,7 @@ extension Task {
                             for s in snapshot!.documents {
                                 let task = try? Task(snapshot: s)
                                 if let task = task {
-                                    if task.tagIds.contains(todayTag.id) {
+                                    if task.tagIds.contains(todayTagId) {
                                         count += 1
                                     }
                                 }

--- a/FirstTask/Use Case/AddTodayTag.swift
+++ b/FirstTask/Use Case/AddTodayTag.swift
@@ -8,9 +8,10 @@ class AddTodayTag {
 
         guard let userId = Auth.safeAuth()?.currentUser?.uid else { return }
         let user = User(id: userId)
+        let tagsCollection = user.collection(path: .tags)
+        let tasksCollection = user.collection(path: .tasks)
 
-        user
-            .collection(path: .tags)
+        tagsCollection
             .whereField("kind", isEqualTo: "today")
             .getDocuments(completion: { snapshot, err in
                 guard err == nil else { return }
@@ -18,8 +19,8 @@ class AddTodayTag {
 
                 let todayTag = try? Tag(snapshot: snapshot!.documents[0])
                 if let todayTag = todayTag {
-                    user
-                        .collection(path: .tasks)
+                    let todayTagId = todayTag.id
+                    tasksCollection
                         .whereField("startDate", isGreaterThanOrEqualTo: today.startOfDay)
                         .whereField("startDate", isLessThanOrEqualTo: today.endOfDay)
                         .getDocuments(completion: { snapshot, err in
@@ -29,8 +30,8 @@ class AddTodayTag {
                             for s in snapshot!.documents {
                                 let task = try? Task(snapshot: s)
                                 if let task = task {
-                                    if !task.tagIds.contains(todayTag.id) {
-                                        task.tagIds.append(todayTag.id)
+                                    if !task.tagIds.contains(todayTagId) {
+                                        task.tagIds.append(todayTagId)
                                         do {
                                             try batch.setData(from: task, forDocument: task.documentReference, merge: true)
                                         } catch {


### PR DESCRIPTION
```
[04:16:32]: ▸ ::warning file=/Users/runner/work/first-task/first-task/FirstTask/Use Case/AddTodayTag.swift,line=21,col=21::capture of 'user' with non-Sendable type 'User' in a '@Sendable' closure
[04:16:32]: ▸                     user
[04:16:32]: ▸                     ^
[04:16:32]: ▸ ::warning file=/Users/runner/work/first-task/first-task/FirstTask/Use Case/AddTodayTag.swift,line=32,col=62::capture of 'todayTag' with non-Sendable type 'Tag' in a '@Sendable' closure
[04:16:32]: ▸                                     if !task.tagIds.contains(todayTag.id) {
[04:16:32]: ▸                                                              ^
[04:16:33]: ▸ ::warning file=/Users/runner/work/first-task/first-task/FirstTask/Model/Task.swift,line=184,col=21::capture of 'user' with non-Sendable type 'User' in a '@Sendable' closure
[04:16:33]: ▸                     user
[04:16:33]: ▸                     ^
[04:16:33]: ▸ ::warning file=/Users/runner/work/first-task/first-task/FirstTask/Model/Task.swift,line=200,col=29::capture of 'done' with non-Sendable type '(Int) -> Void' in a '@Sendable' closure
[04:16:33]: ▸                             done(count)
[04:16:33]: ▸                             ^
[04:16:33]: ▸ ::warning file=/Users/runner/work/first-task/first-task/FirstTask/Model/Task.swift,line=194,col=61::capture of 'todayTag' with non-Sendable type 'Tag' in a '@Sendable' closure
[04:16:33]: ▸                                     if task.tagIds.contains(todayTag.id) {
[04:16:33]: ▸                                                             ^
[04:16:33]: ▸ ::warning file=/Users/runner/work/first-task/first-task/FirstTask/Model/Task.swift,line=200,col=29::capture of 'done' with non-Sendable type '(Int) -> Void' in a '@Sendable' closure
[04:16:33]: ▸                             done(count)
[04:16:33]: ▸                             ^
```