### PR TITLE
Run simulator boot in background during setup steps

### DIFF
--- a/.github/workflows/ci-actionlint.yml
+++ b/.github/workflows/ci-actionlint.yml
@@ -31,3 +31,6 @@ jobs:
           reporter: github-pr-review
           fail_level: warning
           filter_mode: nofilter
+          # TODO: Remove once actionlint supports parallel steps syntax (background, wait).
+          # https://github.com/rhysd/actionlint — check releases after v1.7.12.
+          actionlint_flags: -ignore "unexpected key \"background\"" -ignore "step must run script"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,38 +116,11 @@ jobs:
       - name: Set Xcode version
         uses: ./.github/actions/setup-xcode
 
-      - uses: ruby/setup-ruby@v1
-        with:
-          bundler-cache: true
-
-      - uses: jdx/mise-action@v4
-        env:
-          MISE_DISABLE_TOOLS: ruby
-
-      - uses: irgaly/xcode-cache@v1
-        with:
-          key: xcode-cache-deriveddata-${{ github.job }}-${{ github.workflow }}-${{ github.sha }}
-          restore-keys: xcode-cache-deriveddata-${{ github.job }}-${{ github.workflow }}-
-          swiftpm-cache-key: xcode-cache-sourcepackages-${{ github.job }}-${{ github.workflow }}-${{ github.sha }}
-          swiftpm-cache-restore-keys: xcode-cache-sourcepackages-${{ github.job }}-${{ github.workflow }}-
-
-      - name: Setup GoogleService-Info.plist
-        run: |
-          cp FirstTask/Configs/GoogleService-Info-Release.plist.sample FirstTask/Configs/GoogleService-Info-Release.plist
-
-      - name: Cache SwiftPM packages
-        uses: actions/cache@v6
-        with:
-          path: |
-            FirstTaskDependencies/.build
-          key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
-          restore-keys: |
-            ${{ runner.os }}-spm-
-
       # https://github.com/actions/runner-images/issues/12777
       - name: Workaround for hanging simulator
         id: boot_simulator
         timeout-minutes: 12
+        background: true
         run: |
           brew install coreutils -q
 
@@ -191,6 +164,36 @@ jobs:
             echo "::error::Failed to boot simulator after $max attempts."
             exit 1
           fi
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - uses: jdx/mise-action@v4
+        env:
+          MISE_DISABLE_TOOLS: ruby
+
+      - uses: irgaly/xcode-cache@v1
+        with:
+          key: xcode-cache-deriveddata-${{ github.job }}-${{ github.workflow }}-${{ github.sha }}
+          restore-keys: xcode-cache-deriveddata-${{ github.job }}-${{ github.workflow }}-
+          swiftpm-cache-key: xcode-cache-sourcepackages-${{ github.job }}-${{ github.workflow }}-${{ github.sha }}
+          swiftpm-cache-restore-keys: xcode-cache-sourcepackages-${{ github.job }}-${{ github.workflow }}-
+
+      - name: Setup GoogleService-Info.plist
+        run: |
+          cp FirstTask/Configs/GoogleService-Info-Release.plist.sample FirstTask/Configs/GoogleService-Info-Release.plist
+
+      - name: Cache SwiftPM packages
+        uses: actions/cache@v6
+        with:
+          path: |
+            FirstTaskDependencies/.build
+          key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-spm-
+
+      - wait: [boot_simulator]
 
       - name: Test
         run: mise run test --destination "id=$DEVICE_ID"


### PR DESCRIPTION
Move the simulator boot step to right after setup-xcode and add `background: true` so it runs concurrently with ruby/mise/cache setup. Add `wait: [boot_simulator]` before the test step. This overlaps ~30-55s of setup with the ~90s simulator boot.