### PR TITLE
Skip redundant SwiftPM package resolution in scan

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -67,7 +67,8 @@ platform :ios do
   desc "Run tests"
   lane :test do
     scan(
-      scheme: "FirstTask"
+      scheme: "FirstTask",
+      skip_package_dependencies_resolution: true
     )
   end
 end

--- a/mise.toml
+++ b/mise.toml
@@ -42,7 +42,7 @@ run = """
 #!/usr/bin/env bash
 dest="$usage_destination"
 if [ -n "$dest" ]; then
-  bundle exec fastlane scan --scheme FirstTask --destination "$dest"
+  bundle exec fastlane scan --scheme FirstTask --destination "$dest" --skip_package_dependencies_resolution true
 else
   bundle exec fastlane test
 fi


### PR DESCRIPTION
fastlane scan calls `xcodebuild -resolvePackageDependencies` explicitly before `xcodebuild build test`, which already resolves packages internally. With xcode-cache restoring SourcePackages, the explicit resolution is redundant and costs ~2 minutes.